### PR TITLE
LRDOCS-12442 Fixes Margin Spacing for Learn's Documentation Icons

### DIFF
--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-theme-css/src/css/_elements.scss
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-theme-css/src/css/_elements.scss
@@ -99,6 +99,13 @@ blockquote {
 	padding-left: $spacing-default;
 }
 
+img[src^='https://resources.learn.liferay.com/images/analytics-cloud/latest/en/images/'],
+img[src^='https://resources.learn.liferay.com/images/commerce/latest/en/images/'],
+img[src^='https://resources.learn.liferay.com/images/courses/latest/en/images/'],
+img[src^='https://resources.learn.liferay.com/images/dxp/latest/en/images/'] {
+    margin: 0 0.1rem;
+}
+
 input[type='radio'],
 input[type='checkbox'] {
 	vertical-align: middle;


### PR DESCRIPTION
Commit: https://github.com/is-solutions-delivery/liferay-portal/commit/362e082e15d455c26e471cc0107ef095e13521a2

This PR proposes a fix to icon spacing on Liferay Learn. Currently, the site CSS applies `margin: 1rem 0;` to all `li img` elements. In our articles, we add inline icons, which means that the `1rem` leads to unintended and inconsistent spacing. in our articles.

To fix this, I propose a selector that targets img files in the icon folder for each product:

```css
img[src^='https://resources.learn.liferay.com/images/analytics-cloud/latest/en/images/'],
img[src^='https://resources.learn.liferay.com/images/commerce/latest/en/images/'],
img[src^='https://resources.learn.liferay.com/images/courses/latest/en/images/'],
img[src^='https://resources.learn.liferay.com/images/dxp/latest/en/images/'] {
    margin: 0;
}
```

I only tested this using the Chrome dev tools, and I have not tested it using our client extension.

cc. @joseabelenda