### PR TITLE
ISSD-1335 [CP 2.0] Added user permission to view organization

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/layouts/BaseLayout/index.jsx
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/layouts/BaseLayout/index.jsx
@@ -6,6 +6,7 @@
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {useEffect, useRef, useState} from 'react';
 import {Outlet, useParams} from 'react-router-dom';
+import {useGetKoroneikiAccounts} from '~/common/services/liferay/graphql/koroneiki-accounts';
 import {useProjectOrganizations} from '~/routes/home/hooks/useProjectCategoryItems';
 import ProjectBreadcrumb from '../../components/ProjectBreadcrumb/ProjectBreadcrumb';
 import ProjectErrorMessage from '../../components/ProjectErrorMessage';
@@ -22,6 +23,9 @@ const Layout = () => {
 			window.location.reload();
 		}
 	}, [accountKey]);
+
+	const {data} = useGetKoroneikiAccounts();
+	const koroneikiAccounts = data?.c?.koroneikiAccounts;
 
 	const {myUserAccount, organizations, swr} = useProjectOrganizations();
 
@@ -56,11 +60,16 @@ const Layout = () => {
 		(roleBrief) => roleBrief.name === 'Administrator'
 	);
 
+	const isUserProjectList = koroneikiAccounts.items?.some(
+		({externalReferenceCode}) => externalReferenceCode === accountKey
+	);
+
 	const accountPermission =
 		accountInsideOrganization ||
 		isAccountAdministrator ||
 		isLiferayContact ||
-		isTeamMember;
+		isTeamMember ||
+		isUserProjectList;
 
 	if (!accountPermission) {
 		return <ProjectErrorMessage />;

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/resource-permissions.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/resource-permissions.json
@@ -343,6 +343,15 @@
 			"VIEW"
 		],
 		"primKey": "0",
+		"resourceName": "com.liferay.portal.kernel.model.Organization",
+		"roleName": "User",
+		"scope": "1"
+	},
+	{
+		"actionIds": [
+			"VIEW"
+		],
+		"primKey": "0",
 		"resourceName": "com.liferay.expando.kernel.model.ExpandoColumn",
 		"roleName": "User",
 		"scope": "1"


### PR DESCRIPTION
[ISSD-1335](https://liferay.atlassian.net/browse/ISSD-1335)

- ISSD-1335 Added user permission to view organization

      Is necessary for the FLS filter to work and releases access to the organizations the user belongs to.

      Manual steps will be required
      Go to:
      Control Panel > Roles > Regular Roles: User> User: Define Permissions > Users and Organizations

      ORGANIZATION: View = True

      
![ORGANIZATION-View-True (1)](https://github.com/is-solutions-delivery/liferay-portal/assets/17834813/d882bcf5-ddb8-4cdd-baf2-cd9becc2d477)




- ISSD-1335 Added validation for account Permission