### PR TITLE
ISSD-1335 [CP 2.0] Fixed validation of the number of accounts the organization

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/graphql/queries.ts
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/common/services/liferay/graphql/queries.ts
@@ -595,12 +595,12 @@ export const getAccountUserAccountsByExternalReferenceCode = gql`
 `;
 
 export const getOrganizations = gql`
-	query getOrganizations($filter: String) {
+	query getOrganizations($accountPageSize: Int = 20, $filter: String) {
 		organizations(filter: $filter) {
 			items {
 				name
 				id
-				accounts {
+				accounts(pageSize: $accountPageSize) {
 					totalCount
 					items {
 						id

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/home/hooks/useProjectCategoryItems.ts
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/home/hooks/useProjectCategoryItems.ts
@@ -52,6 +52,7 @@ const getFLSOrganizationsAccounts = (client: ApolloClient<any>) => async ({
 	const response = await client.query({
 		query: getOrganizations,
 		variables: {
+			accountPageSize: -1,
 			filter: SearchBuilder.in('id', organizationIds),
 		},
 	});

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/resource-permissions.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/resource-permissions.json
@@ -53,6 +53,15 @@
 	},
 	{
 		"actionIds": [
+			"VIEW"
+		],
+		"primKey": "0",
+		"resourceName": "com.liferay.portal.kernel.model.Organization",
+		"roleName": "User",
+		"scope": "1"
+	},
+	{
+		"actionIds": [
 			"ADD_OBJECT_ENTRY"
 		],
 		"resourceName": "com.liferay.object#[$OBJECT_DEFINITION_ID:AccountFlag$]",


### PR DESCRIPTION
[ISSD-1335](https://liferay.atlassian.net/browse/ISSD-1335)

ISSD-1335 Added user permission to view organization

- Is necessary for the FLS filter to work and releases access to the organizations the user belongs to.

  Manual steps will be required
  Go to:
  Control Panel > Roles > Regular Roles: User> User: Define Permissions > Users and Organizations

  ORGANIZATION: View = True

- ![ORGANIZATION-View-True](https://github.com/is-solutions-delivery/liferay-portal/assets/17834813/46697d43-b23f-41fa-88bb-92b75e36c856)


ISSD-1335 Fixed validation of the number of accounts the organization

