### PR TITLE
ISSD-1335 [CP 2.0] Refactored the logic that blocks access to the account

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/context/index.jsx
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/context/index.jsx
@@ -3,7 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {createContext, useContext, useEffect, useReducer} from 'react';
+import {
+	createContext,
+	useContext,
+	useEffect,
+	useReducer,
+	useState,
+} from 'react';
 import {useAppPropertiesContext} from '../../../common/contexts/AppPropertiesContext';
 import {Liferay} from '../../../common/services/liferay';
 import {
@@ -33,6 +39,7 @@ const AppContextProvider = ({children}) => {
 		subscriptionGroups: undefined,
 		userAccount: undefined,
 	});
+	const [errorOccurred, setErrorOccurred] = useState(false);
 
 	const pageRoutes = routerPath();
 
@@ -68,13 +75,14 @@ const AppContextProvider = ({children}) => {
 					({name}) => name === 'Administrator'
 				);
 
-				const isPartner = data.userAccount?.organizationBriefs?.filter(
-					({name}) => (
-						name !== 'Account Access EU' &&
-						name !== 'Account Access US' && 
-						name !== 'Liferay Staff' && 
-						name !== 'Systems - Provisioning')
-				).length > 0;
+				const isPartner =
+					data.userAccount?.organizationBriefs?.filter(
+						({name}) =>
+							name !== 'Account Access EU' &&
+							name !== 'Account Access US' &&
+							name !== 'Liferay Staff' &&
+							name !== 'Systems - Provisioning'
+					).length > 0;
 
 				const isStaff = data.userAccount?.organizationBriefs?.some(
 					(organization) => organization.name === 'Liferay Staff'
@@ -86,7 +94,7 @@ const AppContextProvider = ({children}) => {
 					isOmniAdmin,
 					isPartner,
 					isProvisioning: isAccountProvisioning,
-					isStaff
+					isStaff,
 				};
 
 				dispatch({
@@ -170,54 +178,62 @@ const AppContextProvider = ({children}) => {
 		};
 
 		const fetchData = async () => {
-			const projectExternalReferenceCode = getAccountKey();
+			try {
+				const projectExternalReferenceCode = getAccountKey();
 
-			if (!projectExternalReferenceCode) {
-				Liferay.Util.navigate(pageRoutes.home());
-			}
+				if (!projectExternalReferenceCode) {
+					Liferay.Util.navigate(pageRoutes.home());
+				}
 
-			const user = await getUser(projectExternalReferenceCode);
+				const user = await getUser(projectExternalReferenceCode);
 
-			if (user) {
-				const isValid = await isValidPage(
-					client,
-					user,
-					projectExternalReferenceCode,
-					ROUTE_TYPES.project
-				);
-
-				if (isValid) {
-					let accountBrief = user.accountBriefs?.find(
-						(accountBrief) =>
-							accountBrief.externalReferenceCode ===
-							projectExternalReferenceCode
+				if (user) {
+					const isValid = await isValidPage(
+						client,
+						user,
+						projectExternalReferenceCode,
+						ROUTE_TYPES.project
 					);
 
-					const apiPermission = 
-						user.isOmniAdmin || user.isPartner || user.isStaff;
+					if (isValid) {
+						let accountBrief = user.accountBriefs?.find(
+							(accountBrief) =>
+								accountBrief.externalReferenceCode ===
+								projectExternalReferenceCode
+						);
 
-					if (!accountBrief && apiPermission) {
-						const {data: dataAccount} = await client.query({
-							query: getAccountByExternalReferenceCode,
-							variables: {
-								externalReferenceCode: projectExternalReferenceCode,
+						const apiPermission =
+							user.isOmniAdmin || user.isPartner || user.isStaff;
+
+						if (!accountBrief && apiPermission) {
+							const {data: dataAccount} = await client.query({
+								query: getAccountByExternalReferenceCode,
+								variables: {
+									externalReferenceCode: projectExternalReferenceCode,
+								},
+							});
+
+							if (dataAccount) {
+								accountBrief =
+									dataAccount?.accountByExternalReferenceCode;
 							}
-						});
-
-						if (dataAccount) {
-							accountBrief =
-								dataAccount?.accountByExternalReferenceCode;
 						}
-					}
 
-					if (accountBrief) {
-						getProject(projectExternalReferenceCode, accountBrief);
-						getSubscriptionGroups(projectExternalReferenceCode);
-					}
+						if (accountBrief) {
+							getProject(
+								projectExternalReferenceCode,
+								accountBrief
+							);
+							getSubscriptionGroups(projectExternalReferenceCode);
+						}
 
-					getStructuredContents();
-					getSessionId();
+						getStructuredContents();
+						getSessionId();
+					}
 				}
+			} catch (error) {
+				console.error('fetchData error:', error);
+				setErrorOccurred(true);
 			}
 		};
 
@@ -226,7 +242,7 @@ const AppContextProvider = ({children}) => {
 	}, [oktaSessionAPI]);
 
 	return (
-		<AppContext.Provider value={[state, dispatch]}>
+		<AppContext.Provider value={[state, dispatch, errorOccurred]}>
 			{children}
 		</AppContext.Provider>
 	);

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/layouts/BaseLayout/index.jsx
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/layouts/BaseLayout/index.jsx
@@ -6,12 +6,15 @@
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {useEffect, useRef, useState} from 'react';
 import {Outlet, useParams} from 'react-router-dom';
-import {useProjectOrganizations} from '~/routes/home/hooks/useProjectCategoryItems';
 import ProjectBreadcrumb from '../../components/ProjectBreadcrumb/ProjectBreadcrumb';
 import ProjectErrorMessage from '../../components/ProjectErrorMessage';
 import SideMenu from '../../containers/SideMenu';
+import {useCustomerPortal} from '../../context';
 
 const Layout = () => {
+	const contextAccount = useCustomerPortal();
+	const errorOccurred = contextAccount[2];
+
 	const [hasSideMenu, setHasSideMenu] = useState(true);
 
 	const {accountKey} = useParams();
@@ -23,47 +26,18 @@ const Layout = () => {
 		}
 	}, [accountKey]);
 
-	const {myUserAccount, organizations, swr} = useProjectOrganizations();
-
-	if (
-		swr.myUserAccountSWR.isLoading ||
-		swr.myUserAccountSWR.isValidating ||
-		swr.organizationsSWR.isLoading ||
-		swr.organizationsSWR.isValidating
-	) {
-		return <ClayLoadingIndicator />;
-	}
-
-	const teamMembersERC = myUserAccount?.accountBriefs?.map(
-		({externalReferenceCode}) => externalReferenceCode
-	);
-	const isTeamMember = teamMembersERC.includes(accountKey);
-
-	const liferayContactERC =
-		myUserAccount.accountBriefs
-			?.filter(({roleBriefs}) =>
-				roleBriefs.some(
-					(roleBrief) => roleBrief.name === 'Provisioning'
-				)
-			)
-			.map(({externalReferenceCode}) => externalReferenceCode) || [];
-
-	const accountInsideOrganization = organizations.some(
-		({externalReferenceCode}) => externalReferenceCode === accountKey
-	);
-	const isLiferayContact = liferayContactERC.includes(accountKey);
-	const isAccountAdministrator = myUserAccount.roleBriefs?.some(
+	const isAccountAdministrator = contextAccount[0].userAccount.roleBriefs?.some(
 		(roleBrief) => roleBrief.name === 'Administrator'
 	);
 
-	const accountPermission =
-		accountInsideOrganization ||
-		isAccountAdministrator ||
-		isLiferayContact ||
-		isTeamMember;
+	const accountPermission = !errorOccurred || isAccountAdministrator;
 
 	if (!accountPermission) {
 		return <ProjectErrorMessage />;
+	}
+
+	if (!contextAccount[0]?.project && !isAccountAdministrator) {
+		return <ClayLoadingIndicator />;
 	}
 
 	return (

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/home/hooks/useProjectCategoryItems.ts
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/home/hooks/useProjectCategoryItems.ts
@@ -168,4 +168,3 @@ const useProjectCategoryItems = () => {
 };
 
 export default useProjectCategoryItems;
-export {useProjectOrganizations};

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/resource-permissions.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/resource-permissions.json
@@ -53,6 +53,15 @@
 	},
 	{
 		"actionIds": [
+			"VIEW"
+		],
+		"primKey": "0",
+		"resourceName": "com.liferay.portal.kernel.model.Organization",
+		"roleName": "User",
+		"scope": "1"
+	},
+	{
+		"actionIds": [
 			"ADD_OBJECT_ENTRY"
 		],
 		"resourceName": "com.liferay.object#[$OBJECT_DEFINITION_ID:AccountFlag$]",


### PR DESCRIPTION
[ISSD-1335](https://liferay.atlassian.net/browse/ISSD-1335)

ISSD-1335 Added user permission to view organization

-  Is necessary for the FLS filter to work and releases access to the organizations the user belongs to.

      Manual steps will be required
      Go to:
      Control Panel > Roles > Regular Roles: User> User: Define Permissions > Users and Organizations

      ORGANIZATION: View = True

      

- ![ORGANIZATION-View-True](https://github.com/is-solutions-delivery/liferay-portal/assets/17834813/16c7b55c-d4ba-4858-8b99-edf77cad6ad2)


ISSD-1335 Refactored the logic that blocks access to the account

- ![You-do-not-have-access-to-this-project](https://github.com/is-solutions-delivery/liferay-portal/assets/17834813/3c10c7d3-bc2c-486b-bbb7-d0e3aa198c2c)

